### PR TITLE
feat: optimize png encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ cast_sign_loss = "allow"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.10"
-image = "0.25"
+image = { version = "0.25", features = ["png"] }
 log = "0.4"
 thiserror = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::{
 
 use clap::{Args, Parser, Subcommand};
 use image::{ImageBuffer, RgbaImage};
+use image_util::ImageBufferExt;
 
 #[macro_use]
 extern crate log;
@@ -277,10 +278,7 @@ fn generate_mipmap_icon(args: &IconArgs) -> Result<(), CommandError> {
 
     image::imageops::crop_imm(&res, 0, 0, total_width, res.height())
         .to_image()
-        .save_with_format(
-            output_name(&args.source, &args.output, None, "png"),
-            image::ImageFormat::Png,
-        )?;
+        .save_optimized_png(output_name(&args.source, &args.output, None, "png"))?;
 
     Ok(())
 }
@@ -401,7 +399,7 @@ fn generate_spritesheet(
 
     // save sheets
     for (sheet, path) in sheets {
-        sheet.save_with_format(path, image::ImageFormat::Png)?;
+        sheet.save_optimized_png(path)?;
     }
 
     let name = output_name(source, &args.output, None, "");


### PR DESCRIPTION
some comparisons based on the [fill stage animations](https://github.com/fgardt/factorio-underground-storage-tank/tree/main/graphics/transparent_top/frames) of [underground-storage-tank](https://mods.factorio.com/mod/underground-storage-tank):

| previous | optimized | change |
|--------|--------|--------|
| `202 KiB` | `36 KiB` | `-82.2%` |
| `850 KiB` | `261 KiB` | `-69.3%` |
| `1.1 MiB` | `589 KiB` | `-47.7%` |
| `997 KiB` | `428 KiB` | `-57.1%` |
| `915 KiB` | `298 KiB` | `-67.4%` |